### PR TITLE
Replace "|" and "\n" in the output of sensu checks, so payload is cor…

### DIFF
--- a/handler-mattermost.rb
+++ b/handler-mattermost.rb
@@ -43,7 +43,7 @@ body = {text: "
   | Component     | #{@event["client"]["name"]}  |
   |--------------:|:-----------------------------|
   | Check         | #{@event["check"]["name"]}   |
-  | Output        | #{@event["check"]["output"]} |
+  | Output        | #{@event["check"]["output"].gsub("|"," ").gsub("\n"," ")} |
   | Occurrences   | #{@event["occurrences"]}     |
   | Status        | #{exiticon} #{exitcode}      |
 


### PR DESCRIPTION
Replace "|" and "\n" in the output of sensu checks, so payload is correctly formatted.